### PR TITLE
CI: Adjust test matrix to use Python 3.8 and 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.8", "3.12"]
 
     env:
       OS: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -55,28 +55,28 @@ and maintaining [MyST Parser] and [sphinx-design].
 
 
 
-[Changelog]: https://github.com/pyveci/sphinx-design-elements/blob/main/CHANGES.md
+[Changelog]: https://github.com/tech-writing/sphinx-design-elements/blob/main/CHANGES.md
 [Chris Holdgraf]: https://github.com/choldgraf
 [Chris Sewell]: https://github.com/chrisjsewell
 [development documentation]: https://sphinx-design-elements.readthedocs.io/en/latest/sandbox.html
 [Documentation]: https://sphinx-design-elements.readthedocs.io/
-[Issues]: https://github.com/pyveci/sphinx-design-elements/issues
-[License]: https://github.com/pyveci/sphinx-design-elements/blob/main/LICENSE
+[Issues]: https://github.com/tech-writing/sphinx-design-elements/issues
+[License]: https://github.com/tech-writing/sphinx-design-elements/blob/main/LICENSE
 [MyST Parser]: https://myst-parser.readthedocs.io/
 [PyPI]: https://pypi.org/project/sphinx-design-elements/
-[Source code]: https://github.com/pyveci/sphinx-design-elements
+[Source code]: https://github.com/tech-writing/sphinx-design-elements
 [sphinx-design]: https://sphinx-design.readthedocs.io/
 [sphinx-design-elements]: https://sphinx-design-elements.readthedocs.io/
 
-[badge-coverage]: https://codecov.io/gh/pyveci/sphinx-design-elements/branch/main/graph/badge.svg
+[badge-coverage]: https://codecov.io/gh/tech-writing/sphinx-design-elements/branch/main/graph/badge.svg
 [badge-downloads-per-month]: https://pepy.tech/badge/sphinx-design-elements/month
-[badge-license]: https://img.shields.io/github/license/pyveci/sphinx-design-elements.svg
+[badge-license]: https://img.shields.io/github/license/tech-writing/sphinx-design-elements.svg
 [badge-package-version]: https://img.shields.io/pypi/v/sphinx-design-elements.svg
 [badge-python-versions]: https://img.shields.io/pypi/pyversions/sphinx-design-elements.svg
 [badge-status]: https://img.shields.io/pypi/status/sphinx-design-elements.svg
-[badge-tests]: https://github.com/pyveci/sphinx-design-elements/actions/workflows/main.yml/badge.svg
-[project-codecov]: https://codecov.io/gh/pyveci/sphinx-design-elements
+[badge-tests]: https://github.com/tech-writing/sphinx-design-elements/actions/workflows/main.yml/badge.svg
+[project-codecov]: https://codecov.io/gh/tech-writing/sphinx-design-elements
 [project-downloads]: https://pepy.tech/project/sphinx-design-elements/
-[project-license]: https://github.com/pyveci/sphinx-design-elements/blob/main/LICENSE
+[project-license]: https://github.com/tech-writing/sphinx-design-elements/blob/main/LICENSE
 [project-pypi]: https://pypi.org/project/sphinx-design-elements
-[project-tests]: https://github.com/pyveci/sphinx-design-elements/actions/workflows/main.yml
+[project-tests]: https://github.com/tech-writing/sphinx-design-elements/actions/workflows/main.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,31 +171,37 @@ markers = [
 line-length = 120
 
 lint.select = [
-  # Bandit
-  "S",
-  # Bugbear
-  "B",
-  # Builtins
-  "A",
-  # comprehensions
-  "C4",
-  # eradicate
-  "ERA",
-  # flake8-2020
-  "YTT",
-  # isort
-  "I",
-  # pandas-vet
-  "PD",
-  # print
-  "T20",
   # Pycodestyle
   "E",
   "W",
   # Pyflakes
   "F",
+  # isort
+  "I",
+  # Bandit
+  "S",
+  # flake8-quotes
+  "Q",
+  # eradicate
+  "ERA",
+  # flake8-2020
+  "YTT",
+  # print
+  "T20",
   # return
   "RET",
+  # pyupgrade
+  # "UP",
+  # flake8-commas
+  # "COM",
+  # future-annotations
+  # "FA",
+  # flake8-type-checking
+  "TCH",
+  # flake8-unused-arguments
+  # "ARG",
+  # flake8-use-pathlib
+  # "PTH"
 ]
 
 lint.extend-ignore = [

--- a/sphinx_design_elements/util/role.py
+++ b/sphinx_design_elements/util/role.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Any, Optional, Union
+from typing import Any, List, Optional, Tuple, Union
 
 from docutils import nodes
 from myst_parser.mocking import MockInliner
@@ -87,7 +87,7 @@ def get_html_page_title(url: str) -> str:
 
 def parse_block_myst(
     self: MockInliner, text: str, lineno: int, memo: Any, parent: nodes.Element, with_container: bool = False
-) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+) -> Tuple[List[nodes.Node], List[nodes.system_message]]:
     """
     Parse the text and return a list of nodes.
 
@@ -109,7 +109,7 @@ def parse_block_myst(
 
 def parse_block_rst(  # pragma: nocover
     self: MockInliner, text: str, lineno: int, memo: Any, parent: nodes.Element
-) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+) -> Tuple[List[nodes.Node], List[nodes.system_message]]:
     """
     mw = MarkdownWrapper()
     res = mw.render(text)


### PR DESCRIPTION
## About

Make sure the package also works on Python 3.8 and higher.