### PR TITLE
Chore: Update development and runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,11 +92,11 @@ dependencies = [
 develop = [
   "black<25",
   "mypy<1.11",
-  "poethepoet<0.26",
-  "pyproject-fmt<1.9",
-  "ruff<0.4",
+  "poethepoet<0.27",
+  "pyproject-fmt<2.2",
+  "ruff<0.5",
   "types-docutils==0.20.0.3",
-  "validate-pyproject<0.17",
+  "validate-pyproject<0.19",
 ]
 docs = [
   "furo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dynamic = [
 ]
 dependencies = [
   "sphinx<7.2",
-  "sphinx-design<1",
+  "sphinx-design<0.6",
 ]
 [project.optional-dependencies]
 develop = [


### PR DESCRIPTION
development: Use most recent versions of poethepoet, pyproject-fmt, ruff, validate-pyproject.
runtime: Downgrade sphinx-design to 0.5.x, because CSS changes downstream projects might not be prepared for.