### PR TITLE
CI: Fix RTD configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,5 @@ python:
 
 sphinx:
   builder: html
+  configuration: docs/conf.py
   fail_on_warning: true


### PR DESCRIPTION
The `sphinx.configuration` key is missing. This key is now required, see our blog post for more information.

https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/