### PR TITLE
CI: Improve test workflow and RTD configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,9 @@ jobs:
         # Install specific Sphinx version, according to test matrix slot.
         uv pip install 'sphinx==${{ matrix.sphinx-version }}'
 
+        # Display Sphinx version.
+        sphinx-build --version
+
     - name: Run linter and software tests
       run: |
         poe check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.14"]
-        sphinx-version: ["6.*", "7.*"]
+        sphinx-version: [
+          "5.*",
+          "6.*",
+          "7.*",
+        ]
         include:
           - python-version: "3.9"
             sphinx-version: "7.*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
     env:
       PYTHON: ${{ matrix.python-version }}
       SPHINX: ${{ matrix.sphinx-version }}
+      UV_SYSTEM_PYTHON: true
 
     name: >
       Sphinx ${{ matrix.sphinx-version }}
@@ -48,22 +49,24 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: x64
-        cache: 'pip'
-        cache-dependency-path: 'pyproject.toml'
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        cache-dependency-glob: |
+          pyproject.toml
+        cache-suffix: ${{ matrix.python-version }}
+        enable-cache: true
+        version: "latest"
 
     - name: Setup project
       run: |
 
-        # `setuptools 0.64.0` adds support for editable install hooks (PEP 660).
-        # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
-        pip install "setuptools>=64" --upgrade
-
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable=.[develop,docs,test]
+        uv pip install --editable='.[develop,docs,test]'
 
         # Install specific Sphinx version, according to test matrix slot.
-        pip install sphinx==${{ matrix.sphinx-version }}
+        uv pip install 'sphinx==${{ matrix.sphinx-version }}'
 
     - name: Run linter and software tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,15 +22,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: [
+          "3.9",
+          "3.14",
+        ]
         sphinx-version: [
           "5.*",
           "6.*",
           "7.*",
         ]
-        include:
-          - python-version: "3.9"
-            sphinx-version: "7.*"
 
     env:
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
 
     env:
       PYTHON: ${{ matrix.python-version }}
+      SPHINX: ${{ matrix.sphinx-version }}
 
     name: >
       Sphinx ${{ matrix.sphinx-version }}
@@ -54,11 +55,11 @@ jobs:
         # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
         pip install "setuptools>=64" --upgrade
 
-        # Install Sphinx beforehand, to implement test matrix.
-        pip install sphinx==${{ matrix.sphinx-version }}
-
         # Install package in editable mode.
         pip install --use-pep517 --prefer-binary --editable=.[develop,docs,test]
+
+        # Install specific Sphinx version, according to test matrix slot.
+        pip install sphinx==${{ matrix.sphinx-version }}
 
     - name: Run linter and software tests
       run: |
@@ -71,6 +72,6 @@ jobs:
       with:
         files: ./coverage.xml
         flags: unittests
-        env_vars: OS,PYTHON
+        env_vars: PYTHON,SPHINX
         name: codecov-umbrella
         fail_ci_if_error: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.11"
+    python: "3.14"
 
 python:
   install:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Downloads per month][badge-downloads-per-month]][project-downloads]
 
 [![Supported Python versions][badge-python-versions]][project-pypi]
+[![Supported Sphinx versions][badge-sphinx-versions]][project-sphinx]
 [![Status][badge-status]][project-pypi]
 [![Package version][badge-package-version]][project-pypi]
 
@@ -73,10 +74,12 @@ and maintaining [MyST Parser] and [sphinx-design].
 [badge-license]: https://img.shields.io/github/license/tech-writing/sphinx-design-elements.svg
 [badge-package-version]: https://img.shields.io/pypi/v/sphinx-design-elements.svg
 [badge-python-versions]: https://img.shields.io/pypi/pyversions/sphinx-design-elements.svg
+[badge-sphinx-versions]: https://img.shields.io/badge/sphinx-5.1%20--%207.1-blue.svg
 [badge-status]: https://img.shields.io/pypi/status/sphinx-design-elements.svg
 [badge-tests]: https://github.com/tech-writing/sphinx-design-elements/actions/workflows/main.yml/badge.svg
 [project-codecov]: https://codecov.io/gh/tech-writing/sphinx-design-elements
 [project-downloads]: https://pepy.tech/project/sphinx-design-elements/
 [project-license]: https://github.com/tech-writing/sphinx-design-elements/blob/main/LICENSE
 [project-pypi]: https://pypi.org/project/sphinx-design-elements
+[project-sphinx]: https://www.sphinx-doc.org/
 [project-tests]: https://github.com/tech-writing/sphinx-design-elements/actions/workflows/main.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ optional-dependencies.test = [
   "pytest-cov<8",
   "pytest-regressions<3",
   "sphinx-pytest<0.3",
+  "verlib2",
 ]
 urls.changelog = "https://github.com/panodata/sphinx-design-elements/blob/main/CHANGES.md"
 urls.documentation = "https://sphinx-design-elements.readthedocs.io/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dependencies = [
   "myst-parser",
   "sphinx<7.2",
   "sphinx-design==0.6.1",
+  "standard-imghdr; python_version>='3.13'",
 ]
 optional-dependencies.develop = [
   "black<26",

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -12,8 +12,14 @@ from pathlib import Path
 from typing import Callable
 
 import pytest
+import sphinx
+from verlib2 import Version
 
 from tests.conftest import SphinxBuilder
+
+if Version(sphinx.__version__) < Version("7"):
+    raise pytest.skip("Snippet tests require Sphinx >= 7", allow_module_level=True)
+
 
 SNIPPETS_PATH = Path(__file__).parent.parent / "docs" / "snippets"
 SNIPPETS_GLOB_RST = list((SNIPPETS_PATH / "rst").glob("[!_]*"))


### PR DESCRIPTION
## About
By installing the designated Sphinx version _after_ the package, we are absolute sure the right version will be tested.

## Details
- More Python and Sphinx versions.
- Use `uv` package manager.
- Modern OS and Python on RTD.