### PR TITLE
Add compatibility with docutils 0.22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
           "3.9",
           "3.14",
         ]
+        docutils-version: [
+          "0.21.*",
+        ]
         sphinx-version: [
           "5.*",
           "6.*",
@@ -33,7 +36,23 @@ jobs:
           "8.*",
         ]
         exclude:
+
+          # Don't validate Sphinx 8 on Python 3.9. It is not supported.
           - python-version: "3.9"
+            docutils-version: "0.21.*"
+            sphinx-version: "8.*"
+
+        include:
+
+          # Validate docutils 0.19, 0.20, and 0.22.
+          - python-version: "3.14"
+            docutils-version: "0.19.*"
+            sphinx-version: "8.*"
+          - python-version: "3.14"
+            docutils-version: "0.20.*"
+            sphinx-version: "8.*"
+          - python-version: "3.14"
+            docutils-version: "0.22.*"
             sphinx-version: "8.*"
 
     env:
@@ -43,6 +62,7 @@ jobs:
 
     name: >
       Sphinx ${{ matrix.sphinx-version }}
+      docutils ${{ matrix.docutils-version }}
       Python ${{ matrix.python-version }}
     steps:
 
@@ -69,8 +89,9 @@ jobs:
         # Install package in editable mode.
         uv pip install --editable='.[develop,docs,test]'
 
-        # Install specific Sphinx version, according to test matrix slot.
+        # Install specific Sphinx and docutils versions, according to test matrix slots.
         uv pip install 'sphinx==${{ matrix.sphinx-version }}'
+        uv pip install 'docutils==${{ matrix.docutils-version }}'
 
         # Display Sphinx version.
         sphinx-build --version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## Unreleased
-- Dependencies: Added compatibility with docutils 0.21 and 0.22
+- Dependencies: Added compatibility with docutils 0.19 - 0.22
 - Dependencies: Added compatibility with sphinx 7 and 8
 
 ## v0.4.0 - 2024-06-27

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## Unreleased
-- Dependencies: Added compatibility with docutils 0.21
+- Dependencies: Added compatibility with docutils 0.21 and 0.22
 - Dependencies: Added compatibility with sphinx 7 and 8
 
 ## v0.4.0 - 2024-06-27

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@
 [![Coverage Status][badge-coverage]][project-codecov]
 [![License][badge-license]][project-license]
 [![Downloads per month][badge-downloads-per-month]][project-downloads]
+[![Status][badge-status]][project-pypi]
 
+[![Package version][badge-package-version]][project-pypi]
 [![Supported Python versions][badge-python-versions]][project-pypi]
 [![Supported Sphinx versions][badge-sphinx-versions]][project-sphinx]
-[![Status][badge-status]][project-pypi]
-[![Package version][badge-package-version]][project-pypi]
+[![Supported docutils versions][badge-docutils-versions]][project-docutils]
 
 
 ## About
@@ -72,6 +73,7 @@ and maintaining [MyST Parser] and [sphinx-design].
 [badge-coverage]: https://codecov.io/gh/tech-writing/sphinx-design-elements/branch/main/graph/badge.svg
 [badge-downloads-per-month]: https://pepy.tech/badge/sphinx-design-elements/month
 [badge-license]: https://img.shields.io/github/license/tech-writing/sphinx-design-elements.svg
+[badge-docutils-versions]: https://img.shields.io/badge/docutils-0.19%20--%200.22-blue.svg
 [badge-package-version]: https://img.shields.io/pypi/v/sphinx-design-elements.svg
 [badge-python-versions]: https://img.shields.io/pypi/pyversions/sphinx-design-elements.svg
 [badge-sphinx-versions]: https://img.shields.io/badge/sphinx-5.1%20--%208.*-blue.svg
@@ -79,6 +81,7 @@ and maintaining [MyST Parser] and [sphinx-design].
 [badge-tests]: https://github.com/tech-writing/sphinx-design-elements/actions/workflows/main.yml/badge.svg
 [project-codecov]: https://codecov.io/gh/tech-writing/sphinx-design-elements
 [project-downloads]: https://pepy.tech/project/sphinx-design-elements/
+[project-docutils]: https://docutils.sourceforge.io/
 [project-license]: https://github.com/tech-writing/sphinx-design-elements/blob/main/LICENSE
 [project-pypi]: https://pypi.org/project/sphinx-design-elements
 [project-sphinx]: https://www.sphinx-doc.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ dynamic = [
 ]
 dependencies = [
   "beautifulsoup4",
-  "docutils<0.22",
   "myst-parser",
   "sphinx<9",
   "sphinx-design==0.6.1",
@@ -94,7 +93,7 @@ optional-dependencies.develop = [
   "poethepoet<1",
   "pyproject-fmt<3",
   "ruff<0.15",
-  "types-docutils<0.22",
+  "types-docutils",
   "validate-pyproject<1",
 ]
 optional-dependencies.docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dynamic = [
 dependencies = [
   "beautifulsoup4",
   "myst-parser",
+  "docutils<0.23",
   "sphinx<9",
   "sphinx-design==0.6.1",
   "standard-imghdr; python_version>='3.13'",
@@ -93,7 +94,7 @@ optional-dependencies.develop = [
   "poethepoet<1",
   "pyproject-fmt<3",
   "ruff<0.15",
-  "types-docutils",
+  "types-docutils<0.23",
   "validate-pyproject<1",
 ]
 optional-dependencies.docs = [

--- a/sphinx_design_elements/util/role.py
+++ b/sphinx_design_elements/util/role.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union, cast
 from urllib.request import urlopen
 
 from bs4 import BeautifulSoup
@@ -57,6 +57,7 @@ def label_from_reference_element(ref: nodes.Node) -> str:
     return ref.astext()
     """
 
+    txt: Optional[nodes.TextElement]
     try:
         txt = next(ref.findall(nodes.TextElement, include_self=False))
     except StopIteration:
@@ -102,10 +103,11 @@ def parse_block_myst(
             self._renderer.nested_render_text(text, lineno, inline=False)
 
     # Extract the reference node from the container paragraph node.
+    ref: Optional[nodes.Node]
     if with_container:
         ref = container.next_node()
     else:
-        ref = container.next_node().next_node()
+        ref = cast("nodes.Node", container.next_node()).next_node()
     if ref:
         return [ref], []
     else:

--- a/tests/test_hyper.py
+++ b/tests/test_hyper.py
@@ -3,7 +3,7 @@ import re
 import pytest
 from sphinx_pytest.plugin import CreateDoctree
 
-from tests.util import render_reference
+from tests.util import patch_snippet_docutils_forward, render_reference
 
 
 def test_hyper_unknown_type(render):
@@ -53,9 +53,8 @@ def test_hyper_mailto_url(sphinx_doctree_no_tr: CreateDoctree):
 def test_hyper_label_pending(sphinx_doctree_no_tr: CreateDoctree):
     content = "{hyper}`foobar`"
     ptree = render_reference(sphinx_doctree_no_tr, content)
-    assert (
-        ptree
-        == """
+    assert ptree == patch_snippet_docutils_forward(
+        """
 <pending_xref refdoc="index" refdomain="std" refexplicit="True" reftarget="foobar" reftype="ref" refwarn="True">
     <inline classes="xref std std-ref">
         foobar
@@ -66,9 +65,8 @@ def test_hyper_label_pending(sphinx_doctree_no_tr: CreateDoctree):
 def test_hyper_intersphinx(sphinx_doctree_no_tr: CreateDoctree):
     content = "{hyper}`foo:bar`"
     ptree = render_reference(sphinx_doctree_no_tr, content)
-    assert (
-        ptree
-        == """
+    assert ptree == patch_snippet_docutils_forward(
+        """
 <pending_xref refdoc="index" refdomain="std" refexplicit="False" reftarget="foo:bar" reftype="ref" refwarn="True">
     <inline classes="xref std std-ref">
         foo:bar
@@ -79,9 +77,8 @@ def test_hyper_intersphinx(sphinx_doctree_no_tr: CreateDoctree):
 def test_hyper_myst(sphinx_doctree_no_tr: CreateDoctree):
     content = "{hyper}`project:index.md`"
     ptree = render_reference(sphinx_doctree_no_tr, content)
-    assert (
-        ptree
-        == """
+    assert ptree == patch_snippet_docutils_forward(
+        """
 <pending_xref refdoc="index" refdomain="doc" refexplicit="True" reftarget="index" reftargetid="True" reftype="myst">
     <inline classes="xref myst">
         project:index.md
@@ -111,9 +108,8 @@ def test_hyper_explicit_title(sphinx_doctree_no_tr: CreateDoctree):
 {hyper}`title <foobar>`
 """
     ptree = render_reference(sphinx_doctree_no_tr, content)
-    assert (
-        ptree
-        == """
+    assert ptree == patch_snippet_docutils_forward(
+        """
 <pending_xref refdoc="index" refdomain="std" refexplicit="True" reftarget="foobar" reftype="ref" refwarn="True">
     <inline classes="xref std std-ref">
         title
@@ -126,9 +122,8 @@ def test_hyper_shield_label(render):
 (foobar)=
 {hyper}`foobar {type=shield}`
 """
-    assert (
-        render(content)
-        == """
+    assert render(content) == patch_snippet_docutils_forward(
+        """
 <reference id_link="True" refid="foobar" reftitle="foobar">
     <image alt="foobar" candidates="{'?': 'https://img.shields.io/badge/foobar-blue'}" uri="https://img.shields.io/badge/foobar-blue">
 """.lstrip()
@@ -140,9 +135,8 @@ def test_hyper_shield_open(render):
 (foobar)=
 {hyper-open}`foobar`
 """
-    assert (
-        render(content)
-        == """
+    assert render(content) == patch_snippet_docutils_forward(
+        """
 <reference id_link="True" refid="foobar" reftitle="foobar">
     <image alt="foobar" candidates="{'?': 'https://img.shields.io/badge/Open-foobar-darkblue'}" uri="https://img.shields.io/badge/Open-foobar-darkblue">
 """.lstrip()
@@ -209,9 +203,8 @@ def test_hyper_card_minimal(render):
 """
     text = render(content, with_container=True)
 
-    assert (
-        text
-        == """
+    assert text == patch_snippet_docutils_forward(
+        """
 <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm sd-card-hover" design_component="card" is_div="True">
     <container classes="sd-card-body" design_component="card-body" is_div="True">
         <paragraph classes="sd-card-text">
@@ -230,9 +223,8 @@ def test_hyper_card_full(render):
 """
     text = render(content, with_container=True)
 
-    assert (
-        text
-        == """
+    assert text == patch_snippet_docutils_forward(
+        """
 <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm sd-card-hover" design_component="card" is_div="True">
     <container classes="sd-card-header" design_component="card-header" is_div="True">
         <paragraph classes="sd-card-text">

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -2,7 +2,7 @@
 Test the documented snippets run correctly.
 
 Contrary to sphinx-design, this test suite is more relaxed on different
-outcomes between rST and MyST renderings, because, due to the nature of
+outcomes between rST and MyST renderings. Due to the nature of
 composite elements, the outcome of more complex nested nodes is often
 not the same, specifically when using multi-line content or
 cross-references within cell/item contents.
@@ -41,14 +41,15 @@ def write_assets(src_path: Path):
 )
 def test_snippets_rst_pre(sphinx_builder: Callable[..., SphinxBuilder], path: Path, file_regression):
     """Test snippets written in RestructuredText (before post-transforms)."""
+    from tests.util import patch_snippet_docutils_reverse
+
     builder = sphinx_builder()
     content = "Heading\n-------" + "\n\n" + path.read_text(encoding="utf8")
     builder.src_path.joinpath("index.rst").write_text(content, encoding="utf8")
     write_assets(builder.src_path)
     builder.build()
-    pformat = builder.get_doctree("index").pformat()
     file_regression.check(
-        pformat,
+        patch_snippet_docutils_reverse(builder.get_doctree("index").pformat()),
         basename=f"snippet_rst_pre_{path.name[:-len(path.suffix)]}",
         extension=".xml",
         encoding="utf8",
@@ -62,13 +63,15 @@ def test_snippets_rst_pre(sphinx_builder: Callable[..., SphinxBuilder], path: Pa
 )
 def test_snippets_myst_pre(sphinx_builder: Callable[..., SphinxBuilder], path: Path, file_regression):
     """Test snippets written in MyST Markdown (before post-transforms)."""
+    from tests.util import patch_snippet_docutils_reverse
+
     builder = sphinx_builder()
     content = "# Heading" + "\n\n\n" + path.read_text(encoding="utf8")
     builder.src_path.joinpath("index.md").write_text(content, encoding="utf8")
     write_assets(builder.src_path)
     builder.build()
     file_regression.check(
-        builder.get_doctree("index").pformat(),
+        patch_snippet_docutils_reverse(builder.get_doctree("index").pformat()),
         basename=f"snippet_myst_pre_{path.name[:-len(path.suffix)]}",
         extension=".xml",
         encoding="utf8",
@@ -82,14 +85,15 @@ def test_snippets_myst_pre(sphinx_builder: Callable[..., SphinxBuilder], path: P
 )
 def test_snippets_rst_post(sphinx_builder: Callable[..., SphinxBuilder], path: Path, file_regression):
     """Test snippets written in RestructuredText (after HTML post-transforms)."""
+    from tests.util import patch_snippet_docutils_reverse
+
     builder = sphinx_builder()
     content = "Heading\n-------" + "\n\n" + path.read_text(encoding="utf8")
     builder.src_path.joinpath("index.rst").write_text(content, encoding="utf8")
     write_assets(builder.src_path)
     builder.build()
-    pformat = builder.get_doctree("index", post_transforms=True).pformat()
     file_regression.check(
-        pformat,
+        patch_snippet_docutils_reverse(builder.get_doctree("index", post_transforms=True).pformat()),
         basename=f"snippet_rst_post_{path.name[:-len(path.suffix)]}",
         extension=".xml",
         encoding="utf8",
@@ -103,13 +107,15 @@ def test_snippets_rst_post(sphinx_builder: Callable[..., SphinxBuilder], path: P
 )
 def test_snippets_myst_post(sphinx_builder: Callable[..., SphinxBuilder], path: Path, file_regression):
     """Test snippets written in MyST Markdown (after HTML post-transforms)."""
+    from tests.util import patch_snippet_docutils_reverse
+
     builder = sphinx_builder()
     content = "# Heading" + "\n\n\n" + path.read_text(encoding="utf8")
     builder.src_path.joinpath("index.md").write_text(content, encoding="utf8")
     write_assets(builder.src_path)
     builder.build()
     file_regression.check(
-        builder.get_doctree("index", post_transforms=True).pformat(),
+        patch_snippet_docutils_reverse(builder.get_doctree("index", post_transforms=True).pformat()),
         basename=f"snippet_myst_post_{path.name[:-len(path.suffix)]}",
         extension=".xml",
         encoding="utf8",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,6 +5,7 @@ import pytest
 from docutils import nodes
 
 from sphinx_design_elements.util.directive import MarkdownWrapper, SmartReference, link_to_markdown
+from tests.util import patch_snippet_docutils_forward
 
 
 @dataclasses.dataclass
@@ -117,4 +118,6 @@ def test_link_to_markdown_all_options():
 def test_markdown_wrapper():
     mw = MarkdownWrapper()
     outcome = mw.render('[label](#document "title")')[0].next_node(nodes.reference)
-    assert str(outcome) == '<reference id_link="True" reftitle="title" refuri="#document">label</reference>'
+    assert str(outcome) == patch_snippet_docutils_forward(
+        '<reference id_link="True" reftitle="title" refuri="#document">label</reference>'
+    )

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,11 +1,13 @@
 import os
 from unittest.mock import patch
 
+import docutils
 from docutils import nodes
 from sphinx import addnodes
 from sphinx.errors import SphinxError
 from sphinx.testing.util import SphinxTestApp
 from sphinx_pytest.plugin import AppWrapper, CreateDoctree
+from verlib2 import Version
 
 from sphinx_design_elements.hyper import setup_hyper
 from tests.conftest import SphinxBuilder
@@ -81,3 +83,37 @@ def render_reference_builder(builder: SphinxBuilder, content: str) -> str:
     builder.build()
 
     return find_reference(clean_doctree(builder.get_doctree("index", post_transforms=True))).pformat()
+
+
+def patch_snippet_docutils_forward(snippet: str) -> str:
+    """
+    docutils 0.22 returns a few boolean values as integer values.
+    """
+    if Version(docutils.__version__) >= Version("0.22"):
+        snippet = (
+            snippet.replace('has_title="True"', 'has_title="1"')
+            .replace('id_link="True"', 'id_link="1"')
+            .replace('is_div="True"', 'is_div="1"')
+            .replace('refexplicit="True"', 'refexplicit="1"')
+            .replace('refexplicit="False"', 'refexplicit="0"')
+            .replace('refwarn="True"', 'refwarn="1"')
+            .replace('opened="False"', 'opened="0"')
+        )
+    return snippet
+
+
+def patch_snippet_docutils_reverse(snippet: str) -> str:
+    """
+    docutils 0.22 returns a few boolean values as integer values.
+    """
+    if Version(docutils.__version__) >= Version("0.22"):
+        snippet = (
+            snippet.replace('has_title="1"', 'has_title="True"')
+            .replace('id_link="1"', 'id_link="True"')
+            .replace('is_div="1"', 'is_div="True"')
+            .replace('refexplicit="1"', 'refexplicit="True"')
+            .replace('refexplicit="0"', 'refexplicit="False"')
+            .replace('refwarn="1"', 'refwarn="True"')
+            .replace('opened="0"', 'opened="False"')
+        )
+    return snippet


### PR DESCRIPTION
## About

docutils 0.22 was released on July 29, 2025.

## What's inside

- Dependencies: Add compatibility with docutils 0.22
- Dependencies: Limit installation to `docutils<0.23`
- CI: Add test matrix for docutils 0.19 - 0.22
