### PR TITLE
Support for Sphinx 9

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## Unreleased
+- Dependencies: Permitted installation of sphinx-design 0.7.0,
+  effectively enabling support for Sphinx 9.
 
 ## v0.4.1 - 2025-12-14
 - Dependencies: Added compatibility with docutils 0.19 - 0.22

--- a/docs/hyper.md
+++ b/docs/hyper.md
@@ -1191,8 +1191,6 @@ Shield shortcut roles help saving a few keystrokes. Examples:
 `hyper-navigate`, `hyper-open`, `hyper-tutorial`, `hyper-read-more`,
 `hyper-readme-github`, `hyper-nb-colab`, `hyper-nb-binder`, `hyper-nb-github`.
 
----
-
 {hyper-navigate}`https://example.org`
 {hyper-open}`https://example.org`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
   "docutils<0.23",
   "myst-parser",
   "sphinx<10",
-  "sphinx-design==0.6.1",
+  "sphinx-design>=0.6.1,<0.8",
   "standard-imghdr; python_version>='3.13'",
 ]
 optional-dependencies.develop = [


### PR DESCRIPTION
## About
Make the package support Sphinx 9 by permitting installation of sphinx-design 0.7.0. Thank you, @chrisjsewell!

## References
- https://github.com/crate/crate-docs-theme/pull/671
- GH-167
- https://github.com/executablebooks/sphinx-design/issues/245
- https://github.com/executablebooks/sphinx-design/pull/255