### PR TITLE
CI: Remove `black --check`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,7 +233,6 @@ tasks.format = [
 ]
 tasks.lint = [
   { cmd = "ruff check ." },
-  { cmd = "black --check ." },
   { cmd = "validate-pyproject pyproject.toml" },
   { cmd = "mypy" },
 ]


### PR DESCRIPTION
It fails on Python 3.9.